### PR TITLE
[a11y] remove it from the accessibility tree

### DIFF
--- a/src/js/core/private.js
+++ b/src/js/core/private.js
@@ -1137,6 +1137,7 @@ var _createHtmlBridge = function() {
   var container = _document.createElement("div");
   container.id = _globalConfig.containerId;
   container.className = _globalConfig.containerClass;
+  container.setAttribute('aria-hidden', true);
   container.style.position = "absolute";
   container.style.left = "0px";
   container.style.top = "-9999px";


### PR DESCRIPTION
Tools to detect automatic accessibility errors show an error on zeroclipboard.
https://dequeuniversity.com/rules/axe/2.1/object-alt?application=axeChrome

As this element don't provide any content, the best way is to remove the element from the accessibility tree.